### PR TITLE
Fixes to fscp --update

### DIFF
--- a/fs/utils.py
+++ b/fs/utils.py
@@ -61,6 +61,8 @@ def copyfile(src_fs, src_path, dst_fs, dst_path, overwrite=True, update=False,
 
     """
 
+    assert_write(src_fs, src_path, dst_fs, dst_path, overwrite, update)
+
     # If the src and dst fs objects are the same, then use a direct copy
     if src_fs is dst_fs:
         src_fs.copy(src_path, dst_path, overwrite=overwrite)
@@ -68,8 +70,6 @@ def copyfile(src_fs, src_path, dst_fs, dst_path, overwrite=True, update=False,
 
     src_syspath = src_fs.getsyspath(src_path, allow_none=True)
     dst_syspath = dst_fs.getsyspath(dst_path, allow_none=True)
-
-    assert_write(src_fs, src_path, dst_fs, dst_path, overwrite, update)
 
     # System copy if there are two sys paths
     if src_syspath is not None and dst_syspath is not None:


### PR DESCRIPTION
This pull request includes a couple of fixes for bugs in the new `--update` mechanism added to `fscp`.
- The wrong argument was being passed to get the modified date of a file, causing `--update` to behave strangely
- If you're copying from two of the same filesystem, the call to `assert_write` still applies to ensure `--update` does what it's supposed to
