### PR TITLE
Add username to driver, allow buffering.

### DIFF
--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -15,6 +15,7 @@ enable WebHDFS for this filesystem to be usable.
 
 import fnmatch
 import getpass
+import io
 import json
 import os
 import re
@@ -129,7 +130,7 @@ class HadoopFS(FS):
             raise fs.errors.ResourceInvalidError
 
         if buffering == 1:
-            self.buffersize = 4*1024
+            self.buffersize = io.DEFAULT_BUFFER_SIZE
         elif buffering > 1:
             self.buffersize = buffering
 

--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -74,7 +74,7 @@ class HadoopFS(FS):
 
     @hdfs_errors
     def __init__(self, namenode, port="50070", base="/",
-                 thread_synchronize=False):
+                 thread_synchronize=False, user=getpass.getuser()):
         """Initialize an instance of the HadoopFS Filesystem class.
 
         Currently, only HDFS deployments with security off are supported, and
@@ -92,7 +92,7 @@ class HadoopFS(FS):
         self.client = pywebhdfs.webhdfs.PyWebHdfsClient(
             namenode,
             port=port,
-            user_name=getpass.getuser()
+            user_name=user
         )
 
         # Create the HDFS base path if needed. This works as `mkdir -p`. If

--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -518,5 +518,5 @@ class _HadoopFileLike(FileLikeBase):
         :raises: FSError if write was not successful
         """
 
-        self.client.append_file(self.hdfs_path, data)
+        self.client.append_file(self.hdfs_path, data, 16384)
         return None

--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -108,7 +108,7 @@ class HadoopFS(FS):
 
         :param path: a path that should be opened
         :param mode: mode of file to open (supported: 'r', 'w', and 'a')
-        :param buffering: ignored
+        :param buffering: size of buffer
         :param encoding: ignored
         :param errors: ignored
         :param newline: ignored
@@ -127,6 +127,11 @@ class HadoopFS(FS):
 
         if is_dir:
             raise fs.errors.ResourceInvalidError
+
+        if buffering == 1:
+            self.buffersize = 4*1024
+        elif buffering > 1:
+            self.buffersize = buffering
 
         # Create the file if needed
         if not is_file:
@@ -502,7 +507,8 @@ class _HadoopFileLike(FileLikeBase):
         if self.eof:
             return None
 
-        contents = self.client.read_file(self.hdfs_path)
+        contents = self.client.read_file(self.hdfs_path, buffersize=self.buffersize)
+
         self.eof = True
         return contents
 
@@ -518,5 +524,5 @@ class _HadoopFileLike(FileLikeBase):
         :raises: FSError if write was not successful
         """
 
-        self.client.append_file(self.hdfs_path, data, 16384)
+        self.client.append_file(self.hdfs_path, data, buffersize=self.buffersize)
         return None


### PR DESCRIPTION
Add username flag to driver initialization, to enable ACL's in HDFS. Also allow a buffersize for subsequent commands - this might fix the write performance problems I've been observing.