### PR TITLE
[DD-4305] Pull the username from HADOOP_USER_NAME if set

### DIFF
--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -74,7 +74,7 @@ class HadoopFS(FS):
 
     @hdfs_errors
     def __init__(self, namenode, port="50070", base="/",
-                 thread_synchronize=False, user=getpass.getuser()):
+                 thread_synchronize=False, user=None):
         """Initialize an instance of the HadoopFS Filesystem class.
 
         Currently, only HDFS deployments with security off are supported, and
@@ -85,8 +85,12 @@ class HadoopFS(FS):
         :param base: Base path to namespace this filesystem in. If the base
                      path does not exist, the corresponding directory is
                      created.
+        :param user: The user to connect to HDFS with
         :raises: FSError if the base path cannot be created
         """
+
+        if not user:
+            user = os.environ.get("HADOOP_USER_NAME", getpass.getuser())
 
         self.base = base
         self.client = pywebhdfs.webhdfs.PyWebHdfsClient(


### PR DESCRIPTION
Review Notes
-----

| Key     | Value                        |
| ------- | ---------------------------- |
| JIRA    | [DD-4305](https://duedil.atlassian.net/browse/DD-4305)  |

Description
-----

To bring the filesystem in line with the environment variables supported by the standard `hadoop` command line tools, i've added support for the `HADOOP_USER_NAME` environment variable which will be used as a default (above the current user) if no specific user is given.