### PR TITLE
set timeout to None while invoking pywebhdfs

### DIFF
--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -99,7 +99,8 @@ class HadoopFS(FS):
         self.client = pywebhdfs.webhdfs.PyWebHdfsClient(
             namenode,
             port=port,
-            user_name=user
+            user_name=user,
+            timeout=None
         )
 
         # Create the HDFS base path if needed. This works as `mkdir -p`. If


### PR DESCRIPTION
By default, the timeout is set to 0, and this breaks requests. Setting this to None fixes this issue.
This is due to a bug in python requests.
https://github.com/kennethreitz/requests/issues/2699
