### PR TITLE
[DD-7067] Now only strips off prefixed slashes if the path is not empty

### DIFF
--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -110,7 +110,8 @@ class HadoopFS(FS):
         # Only lstrip '/' if base isn't empty
         # You can't have '' as the base.
         base = base.lstrip('/')
-        if base == '': base='/'
+        if base == '':
+            base='/'
         self.client.make_dir(base)
 
         super(HadoopFS, self).__init__(thread_synchronize=thread_synchronize)
@@ -499,7 +500,8 @@ class HadoopFS(FS):
             # Only lstrip '/' off the hdfs_path if it's not an empty path.
             # You can't run ls on ''
             stripped_hdfs_path = hdfs_path.lstrip("/")
-            if stripped_hdfs_path == '': stripped_hdfs_path='/'
+            if stripped_hdfs_path == '':
+                stripped_hdfs_path='/'
             ls = self.client.list_dir(stripped_hdfs_path)
         except pywebhdfs.errors.FileNotFound:
             raise fs.errors.ResourceNotFoundError

--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -106,7 +106,12 @@ class HadoopFS(FS):
         # Create the HDFS base path if needed. This works as `mkdir -p`. If
         # the remote is an existing file, an exception is thrown. Any
         # authenticated errors will result in an exception here too.
-        self.client.make_dir(base.lstrip("/"))
+
+        # Only lstrip '/' if base isn't empty
+        # You can't have '' as the base.
+        base = base.lstrip('/')
+        if base == '': base='/'
+        self.client.make_dir(base)
 
         super(HadoopFS, self).__init__(thread_synchronize=thread_synchronize)
 
@@ -491,7 +496,11 @@ class HadoopFS(FS):
         """
 
         try:
-            ls = self.client.list_dir(hdfs_path.lstrip("/"))
+            # Only lstrip '/' off the hdfs_path if it's not an empty path.
+            # You can't run ls on ''
+            stripped_hdfs_path = hdfs_path.lstrip("/")
+            if stripped_hdfs_path == '': stripped_hdfs_path='/'
+            ls = self.client.list_dir(stripped_hdfs_path)
         except pywebhdfs.errors.FileNotFound:
             raise fs.errors.ResourceNotFoundError
 


### PR DESCRIPTION
If the base path is not provided or set to /, it tries to access '' resulting in a 404.
This has been fixed by only stripping off the slash if the path is not empty.
