### PR TITLE
Don't mkdir() on construction

### DIFF
--- a/fs/hadoop.py
+++ b/fs/hadoop.py
@@ -103,17 +103,6 @@ class HadoopFS(FS):
             timeout=None
         )
 
-        # Create the HDFS base path if needed. This works as `mkdir -p`. If
-        # the remote is an existing file, an exception is thrown. Any
-        # authenticated errors will result in an exception here too.
-
-        # Only lstrip '/' if base isn't empty
-        # You can't have '' as the base.
-        base = base.lstrip('/')
-        if base == '':
-            base='/'
-        self.client.make_dir(base)
-
         super(HadoopFS, self).__init__(thread_synchronize=thread_synchronize)
 
     @hdfs_errors

--- a/fs/tests/test_hadoop.py
+++ b/fs/tests/test_hadoop.py
@@ -50,6 +50,8 @@ class TestHadoopFS(unittest.TestCase, FSTestCases, ThreadingTestCases):
             base=self.root_path
         )
 
+        self.root_fs.makedir(self.base_path, recursive=True)
+
         self.fs = hadoop.HadoopFS(
             namenode=self.namenode_host,
             port=self.namenode_port,


### PR DESCRIPTION
This was a cheap hack, basically the issue here is that you could be opening the filesystem for read access only, and you don't have permission to write. So the mkdir will fail, or do things you don't want (like create the directory with the wrong perms).
